### PR TITLE
Media queries for live and Judges. 

### DIFF
--- a/src/components/Countdown.js
+++ b/src/components/Countdown.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types'
-
+import './css/Countdown.css';
 
 class Countdown extends Component {
   constructor(props) {
@@ -79,16 +79,16 @@ class Countdown extends Component {
     const countDown = this.state;
 
     return (
-      <div className="Countdown" style={{color: 'white', fontSize: '30px', fontWeight: '150'}}>
+      <div className="Countdown">
         <span className="Countdown-col">
-          <span className="Countdown-col-element">
+          <span className="Countdown-col-element ee">
               <strong>{this.addLeadingZeros(countDown.days)}</strong>
               <span>{countDown.days === 1 ? 'Day' : 'Days'}</span>
           </span>
         </span>
 
         <span className="Countdown-col">
-          <span className="Countdown-col-element" style={{paddingLeft: '20px', paddingRight: '10px'}}>
+          <span className="Countdown-col-element a">
             <strong>{this.addLeadingZeros(countDown.hours)}</strong>
             <span>Hours</span>
           </span>
@@ -96,14 +96,14 @@ class Countdown extends Component {
 
 
         <span className="Countdown-col">
-          <span className="Countdown-col-element" style={{paddingLeft: '10px', paddingRight: '20px'}}>
+          <span className="Countdown-col-element b">
             <strong>{this.addLeadingZeros(countDown.min)}</strong>
             <span>Min</span>
           </span>
         </span>
 
         <span className="Countdown-col">
-          <span className="Countdown-col-element">
+          <span className="Countdown-col-element c">
             <strong>{this.addLeadingZeros(countDown.sec)}</strong>
             <span>Sec</span>
           </span>

--- a/src/components/Judges.js
+++ b/src/components/Judges.js
@@ -14,19 +14,19 @@ class Judges extends Component {
               <div className="col-4 judgeCol">
                 <div className="craigImgContainer">
                 </div>
-                <h4 className="judgeImgHeader">Craig Schroeder</h4>
+                <h4 className="judgeImgHeader craig">Craig Schroeder</h4>
                 <p className="judgeImgSub">Assistant Professor in CSE Department</p>
               </div>
               <div className="col-4 judgeCol">
                 <div className="mariamImgContainer">
                 </div>
-                <h4 className="judgeImgHeader">Mariam Salloum</h4>
+                <h4 className="judgeImgHeader mariam">Mariam Salloum</h4>
                 <p className="judgeImgSub">Assistant Professor in CSE Department</p>
               </div>
               <div className="col-4 judgeCol">
                 <div className="lependuImgContainer">
                 </div>
-                <h4 className="judgeImgHeader">Paea LePendu</h4>
+                <h4 className="judgeImgHeader paea">Paea LePendu</h4>
                 <p className="judgeImgSub">Assistant Professor in CSE Department</p>
               </div>
             </div>
@@ -34,13 +34,13 @@ class Judges extends Component {
               <div className="col-4 judgeCol">
                 <div className="papaImgContainer">
                 </div>
-                <h4 className="judgeImgHeader">Vagelis Papalexakis</h4>
+                <h4 className="judgeImgHeader vagelis">Vagelis Papalexakis</h4>
                 <p className="judgeImgSub">Assistant Professor in CSE Department</p>
               </div>
               <div className="col-4 judgeCol">
                 <div className="jedImgContainer">
                 </div>
-                <h4 className="judgeImgHeader">Jed Schwendiman</h4>
+                <h4 className="judgeImgHeader jed">Jed Schwendiman</h4>
                 <p className="judgeImgSub">Assistant Dean for Development, BCOE</p>
               </div>
               <div className="col-4 judgeCol">

--- a/src/components/Live.js
+++ b/src/components/Live.js
@@ -18,6 +18,7 @@ class Live extends Component {
   render(){
     return(
       <Animated animationIn="fadeIn" isVisible={true}>
+        <div className="mobilePadder"></div>
         <div className="liveSec1">
           <div className="liveLeft">
             <div className="liveUpperFooter">

--- a/src/components/css/Countdown.css
+++ b/src/components/css/Countdown.css
@@ -1,0 +1,29 @@
+
+.Countdown{
+
+    color: white;
+    font-size: 30px;
+    font-weight: 150;
+
+}
+.Countdown-col-element, a{
+
+    padding-left: 20px;
+    padding-right: 10px;
+
+}
+.Countdown-col-element, b{
+
+    padding-left: 10px;
+    padding-right: 20px;
+
+}
+@media screen and (max-width: 414px){
+
+    .Countdown{
+        font-size: 20px;
+        margin-bottom: 30px;
+    }
+
+
+}

--- a/src/components/css/Judges.css
+++ b/src/components/css/Judges.css
@@ -81,3 +81,45 @@
 .judgeImgSub {
   color: rgba(255, 255, 255, 0.4);
 }
+
+@media screen and (max-width: 414px){
+
+.judgeRow {
+  display: block;
+  margin-left:16%;          
+
+}
+.judgeImgSub {
+  display: inline-block;
+  width: 300%;
+  
+}
+.judgeImgHeader.craig{
+  display: inline-block;
+  margin-left:30%;
+
+}
+.judgeImgHeader.mariam{
+  display: inline-block;
+  margin-left:70%;
+
+}
+.judgeImgHeader.paea{
+  display: inline-block;
+  margin-left:50%;
+
+}
+.judgeImgHeader.vagelis{
+  display: inline-block;
+  margin-left:30%;
+
+}
+.judgeImgHeader.jed{
+  display: inline-block;
+
+
+}
+.innerJudges {
+ height: 2000px;
+}
+}

--- a/src/components/css/Live.css
+++ b/src/components/css/Live.css
@@ -104,3 +104,20 @@
 .liveTitleCont {
   padding-top: 10%;
 }
+@media screen and (max-width: 414px){
+
+  /* .liveUpperFooter {display: none;} */
+  .liveSec2 {display: none;}
+  .liveSec1 {}
+  .liveLeft {
+    width: 100vw;
+  }
+  .liveUpperFooter {padding-top:0px;}
+  .mobilePadder{
+    width: 100vw;
+    height: 150px;
+    padding-bottom: 0;
+    background-color: #394151;
+  }
+
+}


### PR DESCRIPTION
@jshin029 

I added the media queries for the live site and the judges. There is one small thing on the judges I can't seem to address, and that is to expand the width of the panel to the size of the screen. A screenshot is included 

<img width="1680" alt="Screen Shot 2019-11-04 at 9 34 47 PM" src="https://user-images.githubusercontent.com/30582104/68181088-f1266980-ff4a-11e9-9574-8d6ac2cbaf59.png">
